### PR TITLE
Update asyncInput to work with modern React

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,12 +21,13 @@ function asyncInput (ctor) {
     },
 
     render: function () {
-      return this.transferPropsTo(
-        ctor({
+      return React.createElement(
+        ctor,
+        React.__spread({}, this.props, {
           value: this.state.value,
-          onChange: this.onChange,
-          children: this.props.children
-        })
+          onChange: this.onChange
+        }),
+        this.props.children
       )
     }
   })

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.9.0",
   "description": "wrap React inputs so that asynchrous updates don't cause the cursor to jump",
   "main": "index.js",
-  "dependencies": {
-    "react": "~0.9.0"
+  "peerDependencies": {
+    "react": ">=0.12.0"
   },
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
Hi! I've updated the module to work with React 0.12 and higher. Glad this was here. I'd be happy to maintain the package going forward if you're done with it.
